### PR TITLE
Updated webpack-merge importing

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,4 +1,4 @@
-const merge = require('webpack-merge');
+const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 const Dotenv = require('dotenv-webpack');
 module.exports = merge(common, {


### PR DESCRIPTION
When using webpack-merge's new version, it should be imported this way. https://futurestud.io/tutorials/how-to-fix-webpack-merge-is-not-a-function